### PR TITLE
fix electron app module usage

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,6 @@
-var app = require('app');
+var app = require('electron').app;
 var BrowserWindow = require('browser-window');
-var ipc = require('ipc');
+var ipc = require('electron').ipcMain;
 var join = require('path').join;
 var resolve = require('path').resolve;
 


### PR DESCRIPTION
I have an issue with running browser-run on my app. I have a symlink `node_modules/app` to my src directory (it's advice from browserify handbook to avoid relative paths). And it breaks the electron-stream module since it requires 'app' module in `lib/runner.js`. I've changed this last require to use 'electron' package instead.