### PR TITLE
Update electron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "electron-prebuilt": "^1.0.0",
+    "electron": "^1.3.8",
     "stream-read": "^1.1.2"
   },
   "bin": {


### PR DESCRIPTION
Installing `electron-stream` now outputs a warning that `electron-prebuilt` is now superseded by `electron`. This PR fixes the warning. More info: http://electron.atom.io/blog/2016/08/16/npm-install-electron