### PR TITLE
Serve the input bundle from a url instead of in a script tag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "debug": "^2.6.1",
     "electron": "^1.4.4",
     "json-stringify-safe": "^5.0.1",
-    "stream-read": "^1.1.2"
+    "stream-read": "^1.1.2",
+    "tempy": "0.1.0"
   },
   "bin": {
     "electron-stream": "bin/bin.js"

--- a/test.js
+++ b/test.js
@@ -118,7 +118,7 @@ test('no node integration', function(t){
   browser.end('console.log(!!process.version);window.close();');
 });
 
-test('node integraetion', function(t){
+test('node integration', function(t){
   var browser = electron({
     nodeIntegration: true
   });
@@ -169,4 +169,13 @@ test('utf8', function(t){
     t.end();
   }));
   browser.end('var ಠ = "ಠ";console.log(ಠ);window.close();');
+});
+
+test('closing scripts do not break', function(t){
+  var browser = electron();
+  browser.pipe(concat(function(data){
+    t.equal(data.toString(), '</script>\n');
+    t.end();
+  }));
+  browser.end('console.log("</script>");window.close();');
 });


### PR DESCRIPTION
This prevents things from blowing up if the passed in scripts happen to contain the string `"</script>"`. As talked about here https://github.com/juliangruber/tape-run/issues/66

This also spits up the serving styles node integration requires a full .html page served from a `file://` in your current working directory. So it uses a different function to fetch the URL for that than when it starts up a server. 

While at it I switched to storing the source url in an actual temp file unless needed to be in-directory for node integration. If the process is quit unexpectedly (We have thousands of tests, sometimes you need to kill them) the source file doesn't always get cleaned up properly. By storing the files in a proper temp directory the OS cleans them up and they don't litter your working dir. 