### PR TITLE
ecstatic - npm audit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^4.1.0",
-    "ecstatic": "^3.0.0",
+    "ecstatic": "^4.1.2",
     "electron": "^5.0.0",
     "json-stringify-safe": "^5.0.1",
     "stream-read": "^1.1.2",


### PR DESCRIPTION
npm audit won't pass on packages with current version of electron-stream because of this high vulnerability on ecstatic 
https://www.npmjs.com/advisories/830

After this is merged, please update `tape-run` with the latest version of `browser-run`, and `browser-run` with the latest version of `electron-stream`